### PR TITLE
fix: comma between definitions

### DIFF
--- a/lecture_slides/Discrete_Systems/main.tex
+++ b/lecture_slides/Discrete_Systems/main.tex
@@ -142,7 +142,7 @@ we can do the same transformation as before:
 Defining \emph{discrete state space matrix} $\bar{\mathbf A}$ and \emph{discrete control matrix} $\bar{\mathbf B}$ as follows:
 
 \[
-\bar{\mathbf A} = (\mathbf A \Delta t + \mathbf I) \;  \bar{\mathbf B} = \mathbf B \Delta t
+\bar{\mathbf A} = (\mathbf A \Delta t + \mathbf I),\;  \bar{\mathbf B} = \mathbf B \Delta t
 \]
 %
 We get discrete dynamics:


### PR DESCRIPTION
Just a comma between definitions to avoid confusion about the value of A matrix. Previously, it might be seen as A is derived from B