### PR TITLE
fix: optimal J is the minimum of all cost functions

### DIFF
--- a/lecture_slides/Optimal_Control_of_LTI_systems/main.tex
+++ b/lecture_slides/Optimal_Control_of_LTI_systems/main.tex
@@ -54,7 +54,7 @@ where $g(\mathbf  x, \mathbf  u)$ is instantaneous cost.
 Let $J^*$ be the optimal (lowest possible) cost. In other words:
 
 \[
-J^*(\mathbf x(0)) = \underset{\mathbf u(t)}{\inf{}} J(\mathbf x(0), \mathbf u(t))
+J^*(\mathbf x(0)) = \underset{\mathbf u(t)}{\min{}} J(\mathbf x(0), \mathbf u(t))
 \]
 
 


### PR DESCRIPTION
The optimal J(i.e. J star) is the minimum of all possible cost functions. I see no meaning in `inf` symbol there