### PR TITLE
fix: lqr in Matlab

### DIFF
--- a/lecture_slides/Optimal_Control_of_LTI_systems/main.tex
+++ b/lecture_slides/Optimal_Control_of_LTI_systems/main.tex
@@ -233,7 +233,7 @@ This is the Algebraic Riccati equation.
 
 There are a number of ways to solve LQR:
 \begin{itemize}
-    \item In MATLAB there is a function \texttt{[K,S] = lqr(A, B, Q, R)}
+    \item In MATLAB there is a function \texttt{[K,S,P] = lqr(A, B, Q, R), where P=eig(A-B*K)}
     \item In Python, there is \texttt{S = scipy.linalg.solve\_continuous\_are(a, b, q, r)}
     \item In Drake (by MIT and Toyota Research) there is a function \texttt{(K,S) = LinearQuadraticRegulator(A,B,Q,R)}
 \end{itemize}


### PR DESCRIPTION
fix usage of lqr function in MatLab.

According to [this](https://www.mathworks.com/help/control/ref/lqr.html#mw_61013a9a-2193-47de-80ff-79317d041e42) page in the documentation, the output contains the matrix `P` in addition to K, s