### PR TITLE
Automatic upload of built artifacts

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -12,7 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+      - name: Set up git credentials
+        run: |
+          git config --global user.name 'PDF compiler'
+          git config --global user.email 'pdf-compiler@users.noreply.github.com'
 
       - name: Compile LaTeX document Discrete_Systems
         uses: xu-cheng/latex-action@master
@@ -25,3 +29,10 @@ jobs:
         with:
           root_file: main.tex
           working_directory: lecture_slides/Optimal_Control_of_LTI_systems/
+
+      - name: Push built pdfs
+        run: |
+          git add lecture_slides/Discrete_Systems/main.pdf
+          git add lecture_slides/Optimal_Control_of_LTI_systems/main.pdf
+          git commit -m "Add auto-compiled PDFs"
+          git push

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,6 +3,11 @@ name: Build LaTeX document
 on: 
   push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
     branches:
       - master
 
@@ -13,10 +18,6 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
-      - name: Set up git credentials
-        run: |
-          git config --global user.name 'PDF compiler'
-          git config --global user.email 'pdf-compiler@users.noreply.github.com'
 
       - name: Compile LaTeX document Discrete_Systems
         uses: xu-cheng/latex-action@master
@@ -30,9 +31,12 @@ jobs:
           root_file: main.tex
           working_directory: lecture_slides/Optimal_Control_of_LTI_systems/
 
-      - name: Push built pdfs
+      - name: Update compiled PDFs in git repository
+        if: github.event.pull_request.merged == true || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
+          git config --global user.name 'CI PDF compiler'
+          git config --global user.email '<>'
           git add lecture_slides/Discrete_Systems/main.pdf
           git add lecture_slides/Optimal_Control_of_LTI_systems/main.pdf
-          git commit -m "Add auto-compiled PDFs"
+          git commit -m "Update compiled PDFs"
           git push

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -31,6 +31,18 @@ jobs:
           root_file: main.tex
           working_directory: lecture_slides/Optimal_Control_of_LTI_systems/
 
+      - name: Save Discrete_Systems artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: Discrete_Systems.pdf
+          path: lecture_slides/Discrete_Systems/main.pdf
+
+      - name: Save Optimal_Control_of_LTI_systems artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: Optimal_Control_of_LTI_systems.pdf
+          path: lecture_slides/Optimal_Control_of_LTI_systems/main.pdf
+
       - name: Update compiled PDFs in git repository
         if: github.event.pull_request.merged == true || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pull requests with suggestions and improvements, however small or big, are welcome!
 
-The PDFs are not updated automatically. You can either commit your PDF, or wait till it is rebuilt and re-committed, to see your changes. 
-
-
 The changes in lecture slides are going through an automated check.
+
+The PDFs are compiled and updated automatically when PR is merged. You don't need to update them manually.
+They are also uploaded as workflow artifacts for every new commit pushed into this repository. You can use them to see your changes.


### PR DESCRIPTION
This PR adds functionality for automatic commit and push of built PDFs in 2 situations:
* Direct commit and push in master
* PR is closed and merged

The CI runner will automatically commit artifacts and push them into the target branch. This should speed up the overall process. I have tested these changes in my private repo, the workflow should work as expected.

As a side change, I also propose to upload built PDFs to workflow artifacts, as it makes PR reviewing process easier and faster.